### PR TITLE
Implement simple Flask UI

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -76,10 +76,14 @@ def store_timeline(timeline:Timeline):
     log = str(insert_result).replace("\n", "")
     logging.info(f"DB_stored: {insert_result.inserted_id}: {log}")
 
+def list_timelines():
+    result = timeline_collection.find({}, {"timeline_id": 1})
+    return [doc["timeline_id"] for doc in result]
+
 def get_stories(event_list):
     summaries = []
     for event_id in event_list:
-        event = event_collection.find_one({'evnet_id':event_id})
+        event = event_collection.find_one({'event_id':event_id})
         if event != None:
             summaries.append(event['event_summary'])
     return summaries
@@ -150,10 +154,11 @@ def get_state(tl):
             
             'speaker': "", 
             'speaker_character': None, 
-            'output':"", 
-            'user_intent':"", 
-            'context': [], 
-            'event_complete': False
+            'output':"",
+            'user_intent':"",
+            'context': [],
+            'event_complete': False,
+            'pending_user_input': ""
         })
 
 def get_latest_state():

--- a/core/nodes.py
+++ b/core/nodes.py
@@ -89,11 +89,14 @@ def npc_flow(state: NarrativeState) -> NarrativeState:
 
 @log.instrument
 def user_flow(state: NarrativeState) -> NarrativeState:
-    user_input = input()
-    state = state.model_copy(update={"output": user_input})
+    if state.pending_user_input:
+        user_input = state.pending_user_input
+    else:
+        user_input = input()
+    state = state.model_copy(update={"output": user_input, "pending_user_input": ""})
     user_intent = intent_analyzer.run_sync(str(state.model_dump_json())).output
-    return state.model_copy(update={"output": user_input, "user_intent":user_intent, 
-                            "context": state.context+[{"role":"user", 'content':user_input}], 
+    return state.model_copy(update={"output": user_input, "user_intent":user_intent,
+                            "context": state.context+[{"role":"user", 'content':user_input}],
                             "npc_count":0})
 
 @log.instrument
@@ -139,7 +142,8 @@ def wrapup(state: NarrativeState) -> NarrativeState:
         'speaker_character': None, 
         'output':"", 
         'user_intent':"", 
-        'context': [], 
-        'event_complete': False
+        'context': [],
+        'event_complete': False,
+        'pending_user_input': ""
     })
 

--- a/core/state.py
+++ b/core/state.py
@@ -48,6 +48,7 @@ class NarrativeState(BaseModel):
     user_intent:str = ""
     context: List[Dict] = []
     event_complete: bool = False
+    pending_user_input: str = ""
     
 
     def add_context(self, role:Literal['system', 'assistant', 'user'], content:str) -> None:

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Story Maker</title>
+    <style>
+        body { display: flex; font-family: Arial, sans-serif; }
+        #sidebar { width: 200px; border-right: 1px solid #ccc; padding: 10px; }
+        #chat { flex: 1; padding: 10px; overflow-y: auto; }
+        #input-form { margin-top: 10px; }
+        .line { margin-bottom: 8px; white-space: pre-wrap; }
+    </style>
+</head>
+<body>
+    <div id="sidebar">
+        <h3>Timelines</h3>
+        <ul>
+        {% for tl in timelines %}
+            <li><a href="{{ url_for('select_timeline', tl=tl) }}">{{ tl }}</a></li>
+        {% endfor %}
+        </ul>
+    </div>
+    <div id="chat">
+        {% for msg in history %}
+            <div class="line">{{ msg }}</div>
+            {% if '"' in msg %}<div class="line">&nbsp;</div>{% endif %}
+        {% endfor %}
+        <form id="input-form" method="post" action="{{ url_for('send_message') }}">
+            <input name="message" style="width:80%" {% if input_disabled %}disabled{% endif %}>
+            <button type="submit" {% if input_disabled %}disabled{% endif %}>Send</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,56 @@
+from flask import Flask, render_template, request, redirect, url_for
+from core.db import get_latest_state, get_state, list_timelines
+from core.nodes import present_situation, decide_speaker, npc_flow, user_flow, judge_event_end, wrapup
+from core.logconfig import config_logging
+
+app = Flask(__name__)
+config_logging()
+
+graph_state = get_latest_state()
+history = []
+
+def advance_until_user():
+    global graph_state, history
+    while True:
+        if not graph_state.situation:
+            graph_state = present_situation(graph_state)
+            history.append(graph_state.situation)
+        graph_state = decide_speaker(graph_state)
+        if graph_state.turn == 'user':
+            break
+        graph_state = npc_flow(graph_state)
+        history.append(graph_state.output)
+        graph_state = judge_event_end(graph_state)
+        if graph_state.event_complete:
+            graph_state = wrapup(graph_state)
+
+@app.route('/')
+def index():
+    timelines = list_timelines()
+    input_disabled = graph_state.turn != 'user'
+    return render_template('index.html', timelines=timelines, history=history, input_disabled=input_disabled)
+
+@app.post('/send')
+def send_message():
+    global graph_state, history
+    message = request.form.get('message', '')
+    graph_state = graph_state.model_copy(update={'pending_user_input': message})
+    history.append(message)
+    graph_state = user_flow(graph_state)
+    graph_state = judge_event_end(graph_state)
+    if graph_state.event_complete:
+        graph_state = wrapup(graph_state)
+    advance_until_user()
+    return redirect(url_for('index'))
+
+@app.get('/timeline/<tl>')
+def select_timeline(tl):
+    global graph_state, history
+    graph_state = get_state(tl)
+    history.clear()
+    advance_until_user()
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    advance_until_user()
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add pending_user_input state for web input
- fix typo when loading events from database
- reset pending user input in wrapup
- create a basic Flask web app with timeline sidebar and chat
- render novel-style chat history in new index template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496fb877108332ad954d1ecb8d41b3