### PR TITLE
Store and preload contexts with timeline switch

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -90,9 +90,21 @@ def get_memory(timeline_id: str) -> list:
         return doc.get("memory", [])
     return []
 
+def get_event_context(event_id: str) -> list:
+    event = event_collection.find_one({"event_id": event_id})
+    if event:
+        return event.get("context", [])
+    return []
+
 def list_timelines():
     result = timeline_collection.find({}, {"timeline_id": 1})
     return [doc["timeline_id"] for doc in result]
+
+def get_timeline_events(timeline_id: str) -> list:
+    timeline = timeline_collection.find_one({"timeline_id": timeline_id})
+    if timeline:
+        return timeline.get("timeline", [])
+    return []
 
 def get_stories(event_list):
     summaries = []

--- a/core/nodes.py
+++ b/core/nodes.py
@@ -134,7 +134,8 @@ def wrapup(state: NarrativeState) -> NarrativeState:
         situation_id=state.situation_id,
         situation_summary = state.situation,
         event_summary=event,
-        story_summary=story
+        story_summary=story,
+        context=state.context
     ))
     store_timeline(Timeline(
         timeline_id=state.story_id,

--- a/core/state.py
+++ b/core/state.py
@@ -12,8 +12,9 @@ class Event(BaseModel):
     event_id:str = "E_000"
     situation_id:str  = "S_000",
     situation_summary:str='',
-    event_summary:str='', 
-    story_summary:str=''
+    event_summary:str='',
+    story_summary:str='',
+    context: List[Dict] = []
 
 class Situation(BaseModel):
     situation_id:str = 'S_000'


### PR DESCRIPTION
## Summary
- persist event contexts in `Event`
- expose database helpers for contexts and timeline events
- save context to the database in the `wrapup` node
- load and display past contexts when changing timeline

## Testing
- `pytest -q`
- `python test.py` *(fails: OpenAI API key required)*

------
https://chatgpt.com/codex/tasks/task_e_68498fa0df8c833297209e92b407f9d4